### PR TITLE
Add custom header in model APIs

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.3"
+  version: "1.0.4"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -82,6 +82,11 @@ paths:
           type: "string"
           required: true
           description: "auth token"
+        - name: "EEJI-Test-Code"
+          in: "header"
+          type: "string"
+          required: false
+          description: "custom header for testing"
       responses:
         200:
           description: "OK"
@@ -116,6 +121,11 @@ paths:
           type: "string"
           required: true
           description: "auth token"
+        - name: "EEJI-Test-Code"
+          in: "header"
+          type: "string"
+          required: false
+          description: "custom header for testing"
         - name: "model-id"
           in: "header"
           type: "string"


### PR DESCRIPTION
### 설명

이 PR은 mock data를 반환할 수 있도록 /list_model 과 /describe_model에 custom header('EEJI-Test-Code)를 추가합니다.

관련 이슈
[CSI-128](https://ineeji-solutiontf.atlassian.net/browse/CSI-128?atlOrigin=eyJpIjoiMmNkMTFlNjc3YWEyNDg1OWIyNmI1Njg4NjM4OWU1NmUiLCJwIjoiaiJ9)

[CSI-128]: https://ineeji-solutiontf.atlassian.net/browse/CSI-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ