### PR TITLE
[CSI-128] key value '_' 로 적용 및 required field update 

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.4"
+  version: "1.0.5"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -282,21 +282,24 @@ definitions:
       state:
         type: "string"
         description: "The status of the model"
-      created-at:
+      created_at:
         type: "string"
         description: "The datetime when the model is created (ISO format)"
-      updated-at:
+      updated_at:
         type: "string"
         description: "The datetime when the model is updated (ISO format)"
       dataset_name:
         type: "string"
         description: "The name of dataset"
+        required: false
       accuracy:
         type: "number"
         description: "The model accuracy"
+        required: false
       error_rate:
         type: "number"
         description: "The error rate"
+        required: false
 
   model_summary:
     title: model_summary
@@ -320,7 +323,7 @@ definitions:
       state:
         type: "string"
         description: "The status of the model"
-      created-at:
+      created_at:
         type: "string"
         description: "The datetime when the model is created (ISO format)"
 


### PR DESCRIPTION
[수정 사항]
- list_model 및 describe_model 의 response key 값에 대한 이름을  '-' ,  '_' -> ' _' 로 통일합니다. 
- describe_model 의 response 중 dataset_name, accuracy, error_rate 을  optional 로 변경합니다. 

[Related Issue]
[CSI-128](https://ineeji-solutiontf.atlassian.net/browse/CSI-128?atlOrigin=eyJpIjoiZWQ4OWMyZDJlOTdjNDU1NmI5ODUwYjJhMzY2ODUzYzQiLCJwIjoiaiJ9)


[CSI-128]: https://ineeji-solutiontf.atlassian.net/browse/CSI-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ