### PR TITLE
get_model_download_url 시에 isxai download 를 구분할 수 있는 header 값 추가

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -272,6 +272,11 @@ paths:
           required: true
           type: "string"
           description: "model ID to download result"
+        - name: "isxai"
+          in: "header"
+          type: "boolean"
+          required: true
+          description: "xai result or not (True: xai, False: trained model)"
       responses:
         200:
           description: "OK"


### PR DESCRIPTION
기존 : /v1/get_model_download_url/{model_id} => signed url 1개로 발급

변경되는 사항

/v1/get_model_download_url/{model_id} 요청 시, header 의 isxai 가 False 인 경우
: model train 결과의 json 반환

/v1/get_model_download_url/{model_id} 요청 시, header 의 isxai 가 True 인 경우
: xai 결과의 json 반환