### PR TITLE
[CSI-320] /v1/xai_result/count/{model_id} 수정

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.12"
+  version: "1.0.13"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -15,13 +15,18 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1/xai_result/count:
+  /v1/xai_result/count/{model_id}:
     x-summary: Total XAI row count
     get:
       summary: Get total row count of XAI result
       tags:
         - XAI
       parameters:
+        - name: "model_id"
+          in: "path"
+          type: "string"
+          required: true
+          description: "model id"
         - name: "user-id"
           in: "header"
           type: "string"
@@ -41,8 +46,7 @@ paths:
         200:
           description: "OK"
           schema:
-            type: "number"
-            description: "Total row count number"
+            $ref: "#/definitions/xai_result_count"
         401:
           description: "Unauthorized"
           schema:
@@ -370,6 +374,15 @@ paths:
           description: "Internal server error"
 
 definitions:
+  xai_result_count:
+    title: xai_result_count
+    type: "object"
+    required:
+      - "xai_result_count"
+    properties:
+      xai_result_count:
+        type: "number"
+        description: "Total XAI row count"
 
   xai_result:
     title: xai_result


### PR DESCRIPTION
## 설명 
 /v1/xai_result/count/ 관련 업데이트 

# 수정사항
1.  /v1/xai_result/count/{model_id}   와 같이 path 에  model_id 들어가게끔 수정
2.  reponse data 형식을 { xai_result_count : 100 } 와 같은 형식으로 변경