### PR TITLE
[CSI-379] list_model API 에 error_code 를 추가합니다. 

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -189,10 +189,13 @@ paths:
         200:
           description: "OK"
           schema:
-            type: "array"
-            items:
-              type: "object"
-              $ref: "#/definitions/model_summary"
+            type: "object"
+            properties:
+              models:
+                type: "array"
+                items:
+                  type: "object"
+                  $ref: "#/definitions/model_summary"
         401:
           description: "Unauthorized"
           schema:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -608,6 +608,7 @@ definitions:
       - "is_classification"
       - "state"
       - "created_at"
+      - "error_code"
     properties:
       id:
         type: "string"
@@ -627,6 +628,9 @@ definitions:
       created_at:
         type: "string"
         description: "The datetime when the model is created (ISO format)"
+      error_code:
+        type: "number"
+        description: "A specific code identifying the reason for the failure in training."
 
   model_name:
     title: model_name

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.20"
+  version: "1.0.21"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -196,6 +196,10 @@ paths:
                 items:
                   type: "object"
                   $ref: "#/definitions/model_summary"
+        400:
+          description: "Bad Request"
+          schema:
+            $ref: "#/definitions/resp_bad_request"
         401:
           description: "Unauthorized"
           schema:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -630,7 +630,7 @@ definitions:
         description: "The datetime when the model is created (ISO format)"
       error_code:
         type: "number"
-        description: "A specific code identifying the reason for the failure in training."
+        description: "A specific code identifying the reason for the failure in training. (null if no error)"
 
   model_name:
     title: model_name


### PR DESCRIPTION
## 설명
v1/list_model API 변경
1.  error_code 를 추가합니다. 
[메타 데이터 구조 상세](https://docs.google.com/document/d/19lP80LLDBsnNQ27foyVKtP81Jc8XqRLM6GE1POXQIVQ/edit) 에 따라 error_code 를 아래와 같이 정의합니다. 


값 | 메세지
-- | --
1001 | 데이터 샘플이 너무 적거나 많습니다.
1002 | 데이터의 변수가 너무 많습니다.
1003 | 분류 문제 데이터의 unique한 class의 수가 너무 많습니다.
1004 | Target 변수의 값이 단일 class 입니다.
1005 | Target 변수의 값이 수치 데이터로 변환할 수 없는 형식입니다.
그 외 | 관리자에게 문의하세요.

</div></div><!--EndFragment-->
</body>
</html>

2. 기존 [리스트결과] => models:[리스트결과] 타입으로  return 하게 변경합니다. 기존 [리스트결과]

3. Bad Request 400 Error 추가 

## Related Issue
CSI-379