### PR TITLE
[CSI-393] add total_count of v1/list_model API

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.21"
+  version: "1.0.22"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -196,6 +196,9 @@ paths:
                 items:
                   type: "object"
                   $ref: "#/definitions/model_summary"
+              total_count:
+                type: "number"
+                description: "Total count of models"
         400:
           description: "Bad Request"
           schema:


### PR DESCRIPTION
### 설명 
v1/list_model  에 전체 모델 리스트의 개수를 나타내는 total_count  field 를 추가합니다. 


## 참고 
[참고 사이트 ](https://developer.box.com/guides/api-calls/pagination/offset-based/)

![image](https://github.com/user-attachments/assets/f0c93f6b-e623-4b1a-88fc-a0136b2b5973)
