### PR TITLE
[CSI-365] v1/list_model 에 is_canceled 추가

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -687,7 +687,7 @@ definitions:
         type: "number"
         description: "A specific code identifying the reason for the failure in training. (null if no error)"
       is_canceled:
-        type: "boolean"
+        type: "number"
         description: "The flag indicating whether the model is canceled (1: canceled, 0: not canceled)"
 
   model_name:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.23"
+  version: "1.0.24"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -663,6 +663,7 @@ definitions:
       - "state"
       - "created_at"
       - "error_code"
+      - "is_canceled"
     properties:
       id:
         type: "string"
@@ -685,6 +686,9 @@ definitions:
       error_code:
         type: "number"
         description: "A specific code identifying the reason for the failure in training. (null if no error)"
+      is_canceled:
+        type: "boolean"
+        description: "The flag indicating whether the model is canceled (1: canceled, 0: not canceled)"
 
   model_name:
     title: model_name


### PR DESCRIPTION
### 설명 
대기 중 or 학습 중 모델의 취소 기능을 위해
v1/list_model 에 is_canceled column 을 추가합니다. 


### Related Issue 
CSI-365
