### PR TITLE
[EI2-32] 사용자별 조회가능한 symbol 정보 API

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -491,7 +491,7 @@ paths:
         500:
           description: "Internal server error"
 
-  /v2/economy/get_symbol_info:
+  /v2/economy/get_symbol_info: 
     x-summary: Get symbol info
     get:
       summary: Get symbol info

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -491,7 +491,7 @@ paths:
         500:
           description: "Internal server error"
 
-  /v2/get_symbol_info:
+  /v2/economy/get_symbol_info:
     x-summary: Get symbol info
     get:
       summary: Get symbol info

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.0.22"
+  version: "1.1.0"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -491,6 +491,41 @@ paths:
         500:
           description: "Internal server error"
 
+  /v2/get_symbol_info:
+    x-summary: Get symbol info
+    get:
+      summary: Get symbol info
+      tags:
+        - economy_v2
+      parameters:
+        - name: "user-id"
+          in: "header"
+          type: "string"
+          required: true
+          description: "user id"
+        - name: "company-id"
+          in: "header"
+          type: "string"
+          required: true
+          description: "company id"
+        - name: "Authorization"
+          in: "header"
+          type: "string"
+          required: true
+          description: "auth token"
+        - name: "EEJI-Test-Code"
+          in: "header"
+          type: "string"
+          required: false
+          description: "custom header for testing"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/symbol_info_response"
+        500:
+          description: "Internal server error"
+
 definitions:
   xai_result_count:
     title: xai_result_count
@@ -679,6 +714,20 @@ definitions:
       signed_url:
         type: "string"
         description: "The signed url of the GCS object"
+
+  symbol_info_response:
+    title: symbol_info_response
+    type: "object"
+    required:
+      - "symbols"
+    properties:
+      symbols:
+        type: "object"
+        additionalProperties:
+          type: "array"
+          items:
+            type: "number"
+        description: "A dictionary of symbols and their corresponding numeric arrays"
 
   resp_bad_request:
     type: "object"


### PR DESCRIPTION
### 설명 
사용자별 조회 가능한 Symbol 및 예측 일자의 정보를 제공합니다.
v2 경제지표 작업 시작으로 swagger 의 버전을 version: "1.1.0" 로 두번째 자리를 up 했습니다.

return 결과 예시 
{
  "symbols": {
    "Nickel": [1, 7, 30],
    "zinc": [1, 30, 60, 90]
  }
}

### Related Issue
EI2-32