### PR TITLE
[EI2-43] add /local_attribution_by_date 추가(날짜별 로컬 변수 영향도)

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "1.1.2"
+  version: "1.1.3"
   title: "EEJI Cloudfnt-Backend API Reference"
   description: This document represents API reference of the EEJI Cloudfnt-Backend service.
   license:
@@ -655,6 +655,56 @@ paths:
         500:
           description: "Internal server error"
   
+  /v2/economy/local_attribution_by_date/{symbol}:
+    x-summary: /v2/economy/local_attribution_by_date/{symbol}
+    get:
+      summary: Get global explanation values for a specific symbol and horizons
+      tags:
+        - economy_v2
+      parameters:
+        - name: "symbol"
+          in: "path"
+          type: "string"
+          required: true
+          description: "Symbol identifier (e.g., Hot_Rolled_Coil, Nickel)"
+        - name: "horizon"
+          in: "query"
+          type: "string"
+          required: false
+          description: "horizon values"
+        - name: "date"
+          in: "query"
+          type: "string"
+          required: false
+          description: "date values"
+        - name: "is_pred_date"
+          in: "query"
+          type: "string"
+          required: false
+          description: "is prediction date or not"
+        - name: "user-id"
+          in: "header"
+          type: "string"
+          required: true
+          description: "user id"
+        - name: "company-id"
+          in: "header"
+          type: "string"
+          required: true
+          description: "company id"
+        - name: "Authorization"
+          in: "header"
+          type: "string"
+          required: true
+          description: "auth token"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/local_attribution_by_date_response"
+        500:
+          description: "Internal server error"
+
 
   /v2/economy/global_feature_importance/{symbol}:
     x-summary: /v2/economy/global_feature_importance/{symbol}
@@ -1037,3 +1087,50 @@ definitions:
       detail:
         type: string
         description: "Error reason"
+  
+  local_attribution_by_date_response:
+    title: local_attribution_by_date_response
+    type: "object"
+    required:
+      - "data"
+    properties:
+      data:
+        type: "array"
+        items:
+          type: "object"
+          required:
+            - "feature_impact"
+            - "date"
+            - "date_pred"
+            - "dt"
+            - "horizon"
+            - "is_pred_date"
+            - "name"
+          properties:
+            feature_impact:
+              type: "array"
+              items:
+                type: "object"
+                required:
+                  - "feature_name"
+                  - "impact"
+                properties:
+                  feature_name:
+                    type: "string"
+                    description: "Name of the feature"
+                  impact:
+                    type: "number"
+                    description: "impact value of the feature"
+            name:
+              type: "string"
+              description: "Symbol name"
+            horizon:
+              type: "number"
+              description: "Prediction horizon"
+            dt:
+              type: "string"
+              format: "date"
+              description: "Date of the explanation"
+            is_pred_date:
+              type: "number"
+              description: "Is prediction date or not (1: prediction date, 0: not prediction date)"


### PR DESCRIPTION
### 설명
/local_attribution_by_date 추가

### 응답 포맷
`{
  "data": {
    "feature_impact": [  #feature 별 중요도
      { 
        "feature_name": "KG_Lithium_all", 
        "impact": 0.2504 #빅쿼리 내 테이블 값에서 소수점 4자리 반올림
      },
      {
        "feature_name": "M_PMI_Comp_Purchasing_Volume",
        "impact": 0.1131
      },
      }
    ],
    "name": "Nickel", #symbol 명
    "horizon": 1, #horizon
    "date": "2024-08-31",  #기준 날짜
    "is_pred_date": 0, # (0: 기준 날짜 조회, 1: 예측 결과 날짜 조회) 
    "date_pred": "2024-09-30", # 예측 결과 날짜 
    "dt": "2024-10-29" #데이터 생성 날짜
  }
}
`

### 관련 이슈
[EI2-43](https://eeji.atlassian.net/browse/EI2-43)

[EI2-43]: https://eeji.atlassian.net/browse/EI2-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ